### PR TITLE
colors for 'sent' and 'received' transactions

### DIFF
--- a/bcwallet/bcwallet.py
+++ b/bcwallet/bcwallet.py
@@ -382,7 +382,11 @@ def display_recent_txs(wallet_obj):
                     conf_str,
                     )
             if has_confirmations:
-                puts(colored.green(print_str))
+                sent = 'sent'
+                if sent in print_str:
+                    puts(colored.red(print_str))
+                else:
+                    puts(colored.green(print_str))
             else:
                 puts(colored.yellow(print_str))
     else:


### PR DESCRIPTION
Not a big issue, but it might be easier on the eyes to see 'sent' transactions in red and 'received' transactions in green
